### PR TITLE
Use message index as part of its wrapper element key

### DIFF
--- a/src/components/MessageList/MessageListInner.js
+++ b/src/components/MessageList/MessageListInner.js
@@ -231,7 +231,7 @@ const MessageListInner = (props) => {
   ]);
 
   const elements = useMemo(() => {
-    return enrichedMessages.map((message) => {
+    return enrichedMessages.map((message, index) => {
       if (message.type === 'message.date') {
         if (threadList) return null;
 
@@ -265,7 +265,7 @@ const MessageListInner = (props) => {
         return (
           <li
             className={`str-chat__li str-chat__li--${groupStyles}`}
-            key={message.id || message.created_at}
+            key={`${message.id}-${index}`}
             onLoadCapture={onMessageLoadCaptured}
           >
             <Message


### PR DESCRIPTION
## Description of the pull request
Actually the message li wrapper is using message created at as key value. As a first attempt to resolve the key duplication issue, I'd try to use the message index as part of its wrapper key.