### PR TITLE
do not show first date separator in message list

### DIFF
--- a/src/components/MessageList/VirtualizedMessageList.tsx
+++ b/src/components/MessageList/VirtualizedMessageList.tsx
@@ -213,12 +213,14 @@ const VirtualizedMessageListWithContext = <
       }
 
       const message = messageList[streamMessageIndex];
-
+      const emptyElement = <div style={{ height: '1px' }}></div>
       if (message.customType === 'message.date' && message.date && isDate(message.date)) {
+        // do not show the first date separator in the message list
+        if(streamMessageIndex === 0) return emptyElement
         return <DateSeparator date={message.date} unread={message.unread} />;
       }
 
-      if (!message) return <div style={{ height: '1px' }}></div>; // returning null or zero height breaks the virtuoso
+      if (!message)  return emptyElement; // returning null or zero height breaks the virtuoso
 
       if (message.type === 'system') {
         return <MessageSystem message={message} />;


### PR DESCRIPTION
🎯 Goal
This patch refactors the MessageList component to not show the first date separator.

🛠 Implementation details
In VirtualizedMessagesList component, before we render the date separator we need to check if the message index is equal to 0 (the first message in the list), then return empty div.